### PR TITLE
엔티티, 리포지토리 생성 후 테스트 코드 추가

### DIFF
--- a/src/main/java/kr/mogak/MogakApplication.java
+++ b/src/main/java/kr/mogak/MogakApplication.java
@@ -3,7 +3,9 @@ package kr.mogak;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class MogakApplication {
 

--- a/src/main/java/kr/mogak/entity/BaseTime.java
+++ b/src/main/java/kr/mogak/entity/BaseTime.java
@@ -3,6 +3,7 @@ package kr.mogak.entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import org.hibernate.annotations.Comment;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -16,10 +17,12 @@ import java.time.LocalDateTime;
 public abstract class BaseTime {
 
     @CreatedDate
-    @DateTimeFormat(pattern = "yyyy-MM-dd/HH:mm:ss")
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Comment("생성일자")
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @DateTimeFormat(pattern = "yyyy-MM-dd/HH:mm:ss")
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Comment("수정일자")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/kr/mogak/entity/BaseTime.java
+++ b/src/main/java/kr/mogak/entity/BaseTime.java
@@ -1,0 +1,25 @@
+package kr.mogak.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTime {
+
+    @CreatedDate
+    @DateTimeFormat(pattern = "yyyy-MM-dd/HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @DateTimeFormat(pattern = "yyyy-MM-dd/HH:mm:ss")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/kr/mogak/entity/Member.java
+++ b/src/main/java/kr/mogak/entity/Member.java
@@ -6,15 +6,18 @@ import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Comment;
 
-import java.io.Serializable;
 import java.util.List;
 
+/**
+ * BaseTime - createAt, updateAt 상속
+ */
 @Slf4j
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "t_member")
 @Entity
-public class Member extends BaseTime implements Serializable {
+public class Member extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kr/mogak/entity/Member.java
+++ b/src/main/java/kr/mogak/entity/Member.java
@@ -2,11 +2,11 @@ package kr.mogak.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Comment;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Slf4j
@@ -14,7 +14,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Table(name = "t_member")
 @Entity
-public class Member {
+public class Member extends BaseTime implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,4 +44,8 @@ public class Member {
     @JsonIgnore
     private List<ReplyReport> replyReportList;
 
+    @Builder
+    public Member(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/kr/mogak/entity/Post.java
+++ b/src/main/java/kr/mogak/entity/Post.java
@@ -4,22 +4,23 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import kr.mogak.enums.Category;
 import kr.mogak.enums.Yn;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Comment;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * BaseTime - createAt, updateAt 상속
+ */
 @Slf4j
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "t_post")
 @Entity
-public class Post extends BaseTime implements Serializable {
+public class Post extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("게시글 id")

--- a/src/main/java/kr/mogak/entity/Post.java
+++ b/src/main/java/kr/mogak/entity/Post.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import kr.mogak.enums.Category;
 import kr.mogak.enums.Yn;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Comment;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -17,7 +19,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Table(name = "t_post")
 @Entity
-public class Post {
+public class Post extends BaseTime implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("게시글 id")
@@ -38,17 +40,13 @@ public class Post {
     @Comment("내용")
     private String content;
 
-    @Comment("작성일자")
-    private LocalDateTime createdAt;
-
     @Comment("수정 여부")
-    private Yn updatedYn;
-
-    @Comment("수정일자")
-    private LocalDateTime updatedAt;
+    @Enumerated(EnumType.STRING)
+    private Yn updatedYn = Yn.N;
 
     @Comment("삭제 여부")
-    private Yn deletedYn;
+    @Enumerated(EnumType.STRING)
+    private Yn deletedYn = Yn.N;
 
     @Comment("삭제일자")
     private LocalDateTime deletedAt;
@@ -65,4 +63,13 @@ public class Post {
     @JsonIgnore
     private List<PostUpdateHistory> updatedPosts;
 
+
+    @Builder
+    public Post(Long id, Member author, Category category, String title, String content) {
+        this.id = id;
+        this.author = author;
+        this.category = category;
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/kr/mogak/entity/PostReport.java
+++ b/src/main/java/kr/mogak/entity/PostReport.java
@@ -2,20 +2,22 @@ package kr.mogak.entity;
 
 import jakarta.persistence.*;
 import kr.mogak.enums.ReportReason;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Comment;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
+/**
+ * BaseTime - createAt, updateAt 상속
+ */
 @Slf4j
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "t_post_report")
 @Entity
-public class PostReport extends BaseTime implements Serializable {
+public class PostReport extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kr/mogak/entity/PostReport.java
+++ b/src/main/java/kr/mogak/entity/PostReport.java
@@ -7,15 +7,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Comment;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Slf4j
 @Getter
 @RequiredArgsConstructor
 @Table(name = "t_post_report")
 @Entity
-public class PostReport {
+public class PostReport extends BaseTime implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,12 +38,6 @@ public class PostReport {
 
     @Comment("신고 상세 사유")
     private String reportReasonDetail;
-
-    @Comment("신고일자")
-    private LocalDateTime reportedAt;
-
-    @Comment("수정일자")
-    private LocalDateTime updatedAt;
 
     @Comment("취소일자")
     private LocalDateTime canceledAt;

--- a/src/main/java/kr/mogak/entity/PostUpdateHistory.java
+++ b/src/main/java/kr/mogak/entity/PostUpdateHistory.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Comment;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Slf4j
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 @Table(name = "t_post_update_history")
 @Entity
-public class PostUpdateHistory {
+public class PostUpdateHistory implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("게시글 수정 히스토리 id")

--- a/src/main/java/kr/mogak/entity/PostUpdateHistory.java
+++ b/src/main/java/kr/mogak/entity/PostUpdateHistory.java
@@ -2,20 +2,19 @@ package kr.mogak.entity;
 
 import jakarta.persistence.*;
 import kr.mogak.enums.Category;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Comment;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Slf4j
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "t_post_update_history")
 @Entity
-public class PostUpdateHistory implements Serializable {
+public class PostUpdateHistory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("게시글 수정 히스토리 id")

--- a/src/main/java/kr/mogak/entity/Reply.java
+++ b/src/main/java/kr/mogak/entity/Reply.java
@@ -2,21 +2,23 @@ package kr.mogak.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Comment;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * BaseTime - createAt, updateAt 상속
+ */
 @Slf4j
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "t_reply")
 @Entity
-public class Reply extends BaseTime implements Serializable {
+public class Reply extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kr/mogak/entity/Reply.java
+++ b/src/main/java/kr/mogak/entity/Reply.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Comment;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -15,7 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Table(name = "t_reply")
 @Entity
-public class Reply {
+public class Reply extends BaseTime implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,12 +35,6 @@ public class Reply {
 
     @Comment("내용")
     private String content;
-
-    @Comment("작성일자")
-    private LocalDateTime createdAt;
-
-    @Comment("수정일자")
-    private LocalDateTime updatedAt;
 
     @Comment("삭제일자")
     private LocalDateTime deletedAt;

--- a/src/main/java/kr/mogak/entity/ReplyReport.java
+++ b/src/main/java/kr/mogak/entity/ReplyReport.java
@@ -8,15 +8,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Comment;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Slf4j
 @Getter
 @RequiredArgsConstructor
 @Table(name = "t_reply_report")
 @Entity
-public class ReplyReport {
+public class ReplyReport extends BaseTime implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,12 +39,6 @@ public class ReplyReport {
 
     @Comment("신고 상세 사유")
     private String reportReasonDetail;
-
-    @Comment("신고일자")
-    private LocalDateTime reportedAt;
-
-    @Comment("수정일자")
-    private LocalDateTime updatedAt;
 
     @Comment("취소일자")
     private LocalDateTime canceledAt;

--- a/src/main/java/kr/mogak/entity/ReplyReport.java
+++ b/src/main/java/kr/mogak/entity/ReplyReport.java
@@ -1,22 +1,23 @@
 package kr.mogak.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import kr.mogak.enums.ReportReason;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Comment;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
+/**
+ * BaseTime - createAt, updateAt 상속
+ */
 @Slf4j
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "t_reply_report")
 @Entity
-public class ReplyReport extends BaseTime implements Serializable {
+public class ReplyReport extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kr/mogak/repository/MemberRepository.java
+++ b/src/main/java/kr/mogak/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package kr.mogak.repository;
+
+import kr.mogak.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/kr/mogak/repository/PostRepository.java
+++ b/src/main/java/kr/mogak/repository/PostRepository.java
@@ -1,12 +1,7 @@
 package kr.mogak.repository;
 
-
 import kr.mogak.entity.Post;
-import kr.mogak.enums.Yn;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface PostRepository extends JpaRepository<Post, Long> {
-    List<Post> findByDeletedYn(Yn deleteYn);
 }

--- a/src/test/java/kr/mogak/repository/MemberRepositoryTest.java
+++ b/src/test/java/kr/mogak/repository/MemberRepositoryTest.java
@@ -1,0 +1,39 @@
+package kr.mogak.repository;
+
+import kr.mogak.entity.Member;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class MemberRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @After
+    public void clean() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    public void 멤버를_추가한다() {
+        //given
+        String nickname = "멤버 1";
+        memberRepository.save(Member.builder().nickname(nickname).build());
+
+        //when
+        List<Member> memberList = memberRepository.findAll();
+
+        // then
+        Member member = memberList.get(0);
+        assertThat(member.getNickname().equals(nickname));
+    }
+}

--- a/src/test/java/kr/mogak/repository/PostRepositoryTest.java
+++ b/src/test/java/kr/mogak/repository/PostRepositoryTest.java
@@ -31,11 +31,11 @@ public class PostRepositoryTest {
                 .nickname(nickname)
                 .build());
     }
-//    @After
-//    public void clean() {
-//        postRepository.deleteAll();
-//        memberRepository.deleteAll();
-//    }
+    @After
+    public void clean() {
+        postRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
 
     @Test
     public void 게시글_저장하기() {

--- a/src/test/java/kr/mogak/repository/PostRepositoryTest.java
+++ b/src/test/java/kr/mogak/repository/PostRepositoryTest.java
@@ -1,0 +1,63 @@
+package kr.mogak.repository;
+
+import kr.mogak.entity.Member;
+import kr.mogak.entity.Post;
+import kr.mogak.enums.Category;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class PostRepositoryTest {
+
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    MemberRepository memberRepository;
+
+
+    @Before
+    public void addMember() {
+        String nickname = "멤버 1";
+        memberRepository.save(Member.builder()
+                .nickname(nickname)
+                .build());
+    }
+//    @After
+//    public void clean() {
+//        postRepository.deleteAll();
+//        memberRepository.deleteAll();
+//    }
+
+    @Test
+    public void 게시글_저장하기() {
+        // given
+        Category category = Category.MOGAKCO;
+        String title = "title test";
+        String content = "content test";
+
+        postRepository.save(Post.builder()
+                .author(memberRepository.findAll().get(0))
+                .category(category)
+                .title(title)
+                .content(content)
+                .build()
+        );
+
+        //when
+        List<Post> postList = postRepository.findAll();
+
+        //then
+        Post post = postList.get(0);
+        Assertions.assertThat(post.getTitle().equals(title));
+        Assertions.assertThat(post.getContent().equals(content));
+    }
+}


### PR DESCRIPTION
# 주요 변동 사항
1. `BaseTime` 엔티티를 통해 `createAt`. `updateAt` 코드 중복 회피
2. test 코드를 통해 member 저장, 게시글 저장 확인 